### PR TITLE
Change Create button in add container modal to red

### DIFF
--- a/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.html
+++ b/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.html
@@ -34,7 +34,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" (click)="close()">Cancel</button>
-          <button type="button" class="btn btn-primary" (click)="submit()" [disabled]="isSubmitting">
+          <button type="button" class="btn btn-danger" (click)="submit()" [disabled]="isSubmitting">
             @if (isSubmitting) {
               <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
               <span>Creating...</span>

--- a/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.spec.ts
+++ b/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.spec.ts
@@ -142,4 +142,22 @@ describe('AddContainerModalComponent', () => {
     const req = httpMock.expectOne(`${environment.apiUrl}/api/containers`);
     req.flush({ containerId: 1, name: 'Test', description: '' });
   });
+
+  it('should have red (btn-danger) Create button', () => {
+    component.open();
+    fixture.detectChanges();
+    
+    const createButton = fixture.nativeElement.querySelector('button.btn-danger');
+    expect(createButton).toBeTruthy();
+    expect(createButton.textContent).toContain('Create');
+  });
+
+  it('should not have btn-primary class on Create button', () => {
+    component.open();
+    fixture.detectChanges();
+    
+    const buttons = fixture.nativeElement.querySelectorAll('button.btn-primary');
+    // There should be no btn-primary buttons (Create button should be btn-danger)
+    expect(buttons.length).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
Changes the Create button in the add container modal from blue (btn-primary) to red (btn-danger).

## Changes
- Updated button class from `btn-primary` to `btn-danger` in `add-container-modal.component.html`
- Added tests to verify button has `btn-danger` class and not `btn-primary`

## Testing
- All .NET unit tests pass (40 tests)
- All Angular tests pass (31 tests, including 2 new tests)
- Integration tests require Docker which is not available in the CI environment

Resolves #17