### PR TITLE
Open draft pull request immediately when starting work on an issue

### DIFF
--- a/.cursor/rules/github-issue-implementation-rules.mdc
+++ b/.cursor/rules/github-issue-implementation-rules.mdc
@@ -77,7 +77,7 @@ Before beginning any phase, create a dedicated branch for the issue and open a d
 ## Phase 4: Validation Handoff
 
 1. Update issue labels: remove all existing labels, add `Functional-Validation`
-2. Add the `Functional-Validation` label to the pull request using: `gh pr edit --add-label "Functional-Validation"`
+2. Update pull request labels: remove all existing labels, add `Functional-Validation` using: `gh pr edit --remove-label "<existing-labels>" --add-label "Functional-Validation"`
 
 **Important:** The `Functional-Validation` label cannot be added until `scripts/build_and_test.ps1` completes with no errors. The PR remains in draft status.
 


### PR DESCRIPTION
Closes #19

## Summary

Updates the issue implementation workflow to require opening a draft pull request immediately after creating the feature branch, rather than waiting until development is complete.

## Changes

- **Getting Started section**: Added step 3 to immediately open a draft PR after branch creation, with example commands
- **Phase 3 Development section**: Updated steps 8-9 to mark the existing draft PR as ready for review instead of opening a new PR

## Benefits

- Early visibility into work-in-progress
- Enables ongoing review as changes are committed
- PR is linked to issue from the start of development