### PR TITLE
Fix Cursor API endpoint: /agent -> /agents

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -87,7 +87,7 @@ jobs:
           echo "$PAYLOAD" | jq .
           
           # Make the API call and capture response
-          HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "https://api.cursor.com/agent" \
+          HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "https://api.cursor.com/agents" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $CURSOR_API_KEY" \
             -d "$PAYLOAD")


### PR DESCRIPTION
Fixes the API endpoint from `/agent` to `/agents` per the Cursor Cloud Agent API documentation.