### PR TITLE
Fix Cursor API endpoint to include v0 version prefix

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -87,7 +87,7 @@ jobs:
           echo "$PAYLOAD" | jq .
           
           # Make the API call and capture response
-          HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "https://api.cursor.com/agents" \
+          HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "https://api.cursor.com/v0/agents" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $CURSOR_API_KEY" \
             -d "$PAYLOAD")


### PR DESCRIPTION
Correct endpoint: `https://api.cursor.com/v0/agents`