### PR TITLE
Fix YAML syntax and parameterize repo/ref in workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -12,6 +12,14 @@ on:
         description: 'PR number to review'
         required: true
         type: number
+      repository:
+        description: 'Repository (owner/repo)'
+        required: false
+        type: string
+      ref:
+        description: 'Branch ref to review'
+        required: false
+        type: string
 
 jobs:
   code-review:
@@ -39,58 +47,37 @@ jobs:
         id: pr_details
         env:
           GH_TOKEN: ${{ github.token }}
+          INPUT_REPO: ${{ inputs.repository || github.repository }}
         run: |
-          PR_DATA=$(gh pr view ${{ inputs.pr_number }} --repo ${{ github.repository }} --json number,title,body,headRefName,baseRefName)
+          PR_DATA=$(gh pr view ${{ inputs.pr_number }} --repo ${INPUT_REPO} --json number,title,body,headRefName,baseRefName)
           echo "pr_number=$(echo $PR_DATA | jq -r '.number')" >> $GITHUB_OUTPUT
           echo "pr_title=$(echo $PR_DATA | jq -r '.title')" >> $GITHUB_OUTPUT
-          echo "pr_body<<EOF" >> $GITHUB_OUTPUT
-          echo $PR_DATA | jq -r '.body' >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
           echo "head_branch=$(echo $PR_DATA | jq -r '.headRefName')" >> $GITHUB_OUTPUT
           echo "base_branch=$(echo $PR_DATA | jq -r '.baseRefName')" >> $GITHUB_OUTPUT
 
       - name: Trigger Cursor Cloud Agent Review
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
-          # Use PR event data or manual input data
           PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && steps.pr_details.outputs.pr_number || github.event.pull_request.number }}
           PR_TITLE: ${{ github.event_name == 'workflow_dispatch' && steps.pr_details.outputs.pr_title || github.event.pull_request.title }}
-          PR_BODY: ${{ github.event_name == 'workflow_dispatch' && steps.pr_details.outputs.pr_body || github.event.pull_request.body }}
-          HEAD_BRANCH: ${{ github.event_name == 'workflow_dispatch' && steps.pr_details.outputs.head_branch || github.head_ref }}
+          HEAD_BRANCH: ${{ github.event_name == 'workflow_dispatch' && (inputs.ref || steps.pr_details.outputs.head_branch) || github.head_ref }}
           BASE_BRANCH: ${{ github.event_name == 'workflow_dispatch' && steps.pr_details.outputs.base_branch || github.base_ref }}
+          REPO: ${{ inputs.repository || github.repository }}
         run: |
           echo "Preparing to call Cursor Cloud Agent API..."
           echo "PR Number: ${PR_NUMBER}"
           echo "Head Branch: ${HEAD_BRANCH}"
-          echo "Repository: ${{ github.repository }}"
+          echo "Repository: ${REPO}"
           
-          # Build the prompt text with all PR context
-          PROMPT_TEXT="Review PR #${PR_NUMBER} in repository ${{ github.repository }}.
-
-Follow the code_review_rules to review the changes:
-1. Reference the associated issue to understand requirements
-2. Review the changes against the PR template checklist
-3. Check architecture rules, testing requirements, and documentation
-4. Post a review comment with the checklist findings
-5. Approve if all checks pass, or request changes with specific feedback
-
-PR Title: ${PR_TITLE}
-PR Branch: ${HEAD_BRANCH} -> ${BASE_BRANCH}"
+          # Build the prompt text with all PR context (single line to avoid YAML issues)
+          PROMPT_TEXT="Review PR #${PR_NUMBER} in repository ${REPO}. Follow the code_review_rules to review the changes: 1) Reference the associated issue to understand requirements, 2) Review the changes against the PR template checklist, 3) Check architecture rules, testing requirements, and documentation, 4) Post a review comment with the checklist findings, 5) Approve if all checks pass, or request changes with specific feedback. PR Title: ${PR_TITLE}. PR Branch: ${HEAD_BRANCH} -> ${BASE_BRANCH}"
           
-          # Build the request payload using the correct API format
+          # Build the request payload using jq for proper JSON escaping
           PAYLOAD=$(jq -n \
             --arg prompt "$PROMPT_TEXT" \
-            --arg repo "${{ github.repository }}" \
+            --arg repo "$REPO" \
             --arg ref "$HEAD_BRANCH" \
-            '{
-              "prompt": {
-                "text": $prompt
-              },
-              "source": {
-                "repository": $repo,
-                "ref": $ref
-              }
-            }')
+            '{"prompt": {"text": $prompt}, "source": {"repository": $repo, "ref": $ref}}')
           
           echo "Request payload:"
           echo "$PAYLOAD" | jq .


### PR DESCRIPTION
- Fix multi-line string causing YAML parsing error on line 71
- Add optional repository and ref inputs for manual trigger
- Use REPO env var consistently throughout the workflow