### PR TITLE
Change Create button in add container modal to red

### DIFF
--- a/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.html
+++ b/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.html
@@ -34,7 +34,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" (click)="close()">Cancel</button>
-          <button type="button" class="btn btn-primary" (click)="submit()" [disabled]="isSubmitting">
+          <button type="button" class="btn btn-danger" (click)="submit()" [disabled]="isSubmitting">
             @if (isSubmitting) {
               <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
               <span>Creating...</span>

--- a/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.spec.ts
+++ b/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.spec.ts
@@ -142,4 +142,13 @@ describe('AddContainerModalComponent', () => {
     const req = httpMock.expectOne(`${environment.apiUrl}/api/containers`);
     req.flush({ containerId: 1, name: 'Test', description: '' });
   });
+
+  it('should display Create button with red (btn-danger) styling', () => {
+    component.open();
+    fixture.detectChanges();
+    
+    const createButton = fixture.nativeElement.querySelector('button.btn-danger');
+    expect(createButton).toBeTruthy();
+    expect(createButton.textContent).toContain('Create');
+  });
 });


### PR DESCRIPTION
## Summary
Changed the Create button in the add container modal from blue (btn-primary) to red (btn-danger).

## Changes
- Changed `btn-primary` to `btn-danger` class on the Create button in `add-container-modal.component.html`
- Added unit test to verify the button has the `btn-danger` class

## Testing
- All .NET unit tests pass (40/40)
- All Angular tests pass (30/30) - includes new test for button styling
- Integration tests require Docker which is not available in this environment

Closes #45