### PR TITLE
Users can add a container description when creating a new container

### DIFF
--- a/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.html
+++ b/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.html
@@ -25,6 +25,16 @@
                 </div>
               }
             </div>
+            <div class="mb-3">
+              <label for="containerDescription" class="form-label">Description</label>
+              <textarea 
+                class="form-control" 
+                id="containerDescription" 
+                [(ngModel)]="containerDescription"
+                name="containerDescription"
+                placeholder="Enter container description (optional)"
+                rows="3"></textarea>
+            </div>
             @if (generalError) {
               <div class="alert alert-danger" role="alert">
                 {{ generalError }}

--- a/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.spec.ts
+++ b/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.spec.ts
@@ -60,12 +60,14 @@ describe('AddContainerModalComponent', () => {
 
   it('should reset form when opened', () => {
     component.containerName = 'Test';
+    component.containerDescription = 'Test Description';
     component.validationErrors = { Name: ['Error'] };
     component.generalError = 'General error';
     
     component.open();
     
     expect(component.containerName).toBe('');
+    expect(component.containerDescription).toBe('');
     expect(component.validationErrors).toEqual({});
     expect(component.generalError).toBeNull();
   });
@@ -82,6 +84,27 @@ describe('AddContainerModalComponent', () => {
     expect(req.request.body).toEqual({ name: 'New Container', description: '' });
     
     const mockResponse = { containerId: 1, name: 'New Container', description: '' };
+    req.flush(mockResponse);
+    
+    tick();
+    
+    expect(component.containerCreated.emit).toHaveBeenCalledWith(mockResponse);
+    expect(component.isVisible).toBeFalse();
+  }));
+
+  it('should submit container with description', fakeAsync(() => {
+    spyOn(component.containerCreated, 'emit');
+    
+    component.open();
+    component.containerName = 'New Container';
+    component.containerDescription = 'A test description';
+    component.submit();
+    
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ name: 'New Container', description: 'A test description' });
+    
+    const mockResponse = { containerId: 1, name: 'New Container', description: 'A test description' };
     req.flush(mockResponse);
     
     tick();

--- a/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.ts
+++ b/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.ts
@@ -18,6 +18,7 @@ export class AddContainerModalComponent {
   isVisible = false;
   isSubmitting = false;
   containerName = '';
+  containerDescription = '';
   validationErrors: { [key: string]: string[] } = {};
   generalError: string | null = null;
 
@@ -25,6 +26,7 @@ export class AddContainerModalComponent {
 
   open(): void {
     this.containerName = '';
+    this.containerDescription = '';
     this.validationErrors = {};
     this.generalError = null;
     this.isSubmitting = false;
@@ -43,7 +45,7 @@ export class AddContainerModalComponent {
 
     const request: CreateContainerRequest = {
       name: this.containerName,
-      description: ''
+      description: this.containerDescription
     };
 
     this.containerService.create(request).subscribe({


### PR DESCRIPTION
Closes #59

## Changes
- Added `containerDescription` property to AddContainerModalComponent
- Added description textarea field to the Add Container modal
- Updated form reset logic to clear description on modal open
- Updated submit to send description in the create request
- Added unit test for submitting container with description

## Testing
- All 81 Angular tests pass
- All 87 .NET unit tests pass