### PR TITLE
Users can add a container description when creating a new container

### DIFF
--- a/src/Core/Application/Features/Containers/CreateContainer/CreateContainerCommandHandler.cs
+++ b/src/Core/Application/Features/Containers/CreateContainer/CreateContainerCommandHandler.cs
@@ -21,6 +21,7 @@ public class CreateContainerCommandHandler : ICreateContainerCommandHandler
     }
 
     private const int NameMaxLength = 200;
+    private const int DescriptionMaxLength = 250;
 
     public async Task<ContainerDto> HandleAsync(CreateContainerCommand request, CancellationToken cancellationToken)
     {
@@ -37,6 +38,14 @@ public class CreateContainerCommandHandler : ICreateContainerCommandHandler
             errors[nameof(request.Name)].Add($"Name cannot exceed {NameMaxLength} characters");
         }
 
+        var trimmedDescription = request.Description?.Trim() ?? string.Empty;
+
+        if (trimmedDescription.Length > DescriptionMaxLength)
+        {
+            errors.TryAdd(nameof(request.Description), new List<string>());
+            errors[nameof(request.Description)].Add($"Description cannot exceed {DescriptionMaxLength} characters");
+        }
+
         if (errors.Count > 0)
         {
             throw new ValidationException
@@ -48,7 +57,7 @@ public class CreateContainerCommandHandler : ICreateContainerCommandHandler
         var container = new Container
         {
             Name = request.Name,
-            Description = request.Description
+            Description = trimmedDescription
         };
 
         await _repository.Containers.AddAsync(container, cancellationToken);

--- a/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.html
+++ b/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.html
@@ -25,6 +25,24 @@
                 </div>
               }
             </div>
+            <div class="mb-3">
+              <label for="containerDescription" class="form-label">Description</label>
+              <textarea 
+                class="form-control" 
+                [class.is-invalid]="hasDescriptionError()"
+                id="containerDescription" 
+                [(ngModel)]="containerDescription"
+                name="containerDescription"
+                placeholder="Enter container description (optional)"
+                rows="3"
+                [maxlength]="descriptionMaxLength"></textarea>
+              <div class="form-text">{{ containerDescription.length }}/{{ descriptionMaxLength }} characters</div>
+              @if (hasDescriptionError()) {
+                <div class="invalid-feedback" style="display: block;">
+                  {{ getDescriptionErrors().join(', ') }}
+                </div>
+              }
+            </div>
             @if (generalError) {
               <div class="alert alert-danger" role="alert">
                 {{ generalError }}

--- a/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.spec.ts
+++ b/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.spec.ts
@@ -60,17 +60,40 @@ describe('AddContainerModalComponent', () => {
 
   it('should reset form when opened', () => {
     component.containerName = 'Test';
+    component.containerDescription = 'Test description';
     component.validationErrors = { Name: ['Error'] };
     component.generalError = 'General error';
     
     component.open();
     
     expect(component.containerName).toBe('');
+    expect(component.containerDescription).toBe('');
     expect(component.validationErrors).toEqual({});
     expect(component.generalError).toBeNull();
   });
 
   it('should submit container and emit containerCreated on success', fakeAsync(() => {
+    spyOn(component.containerCreated, 'emit');
+    
+    component.open();
+    component.containerName = 'New Container';
+    component.containerDescription = 'Test description';
+    component.submit();
+    
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ name: 'New Container', description: 'Test description' });
+    
+    const mockResponse = { containerId: 1, name: 'New Container', description: 'Test description' };
+    req.flush(mockResponse);
+    
+    tick();
+    
+    expect(component.containerCreated.emit).toHaveBeenCalledWith(mockResponse);
+    expect(component.isVisible).toBeFalse();
+  }));
+
+  it('should submit container with empty description when not provided', fakeAsync(() => {
     spyOn(component.containerCreated, 'emit');
     
     component.open();
@@ -87,7 +110,6 @@ describe('AddContainerModalComponent', () => {
     tick();
     
     expect(component.containerCreated.emit).toHaveBeenCalledWith(mockResponse);
-    expect(component.isVisible).toBeFalse();
   }));
 
   it('should display validation errors on 400 response', fakeAsync(() => {
@@ -141,5 +163,63 @@ describe('AddContainerModalComponent', () => {
     // Complete the request
     const req = httpMock.expectOne(`${environment.apiUrl}/api/containers`);
     req.flush({ containerId: 1, name: 'Test', description: '' });
+  });
+
+  it('should display description validation errors on 400 response', fakeAsync(() => {
+    component.open();
+    component.containerName = 'Test';
+    component.containerDescription = 'a'.repeat(251);
+    component.submit();
+    
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers`);
+    req.flush(
+      { errors: { Description: ['Description cannot exceed 250 characters'] } },
+      { status: 400, statusText: 'Bad Request' }
+    );
+    
+    tick();
+    fixture.detectChanges();
+    
+    expect(component.hasDescriptionError()).toBeTrue();
+    expect(component.getDescriptionErrors()).toContain('Description cannot exceed 250 characters');
+    expect(component.isVisible).toBeTrue();
+  }));
+
+  it('should have description max length constant set to 250', () => {
+    expect(component.descriptionMaxLength).toBe(250);
+  });
+
+  it('should initialize containerDescription as empty string', () => {
+    expect(component.containerDescription).toBe('');
+  });
+
+  it('hasDescriptionError should return false when no description errors', () => {
+    component.validationErrors = {};
+    expect(component.hasDescriptionError()).toBeFalse();
+  });
+
+  it('hasDescriptionError should return true when Description key has errors', () => {
+    component.validationErrors = { Description: ['Error message'] };
+    expect(component.hasDescriptionError()).toBeTrue();
+  });
+
+  it('hasDescriptionError should return true when description key (lowercase) has errors', () => {
+    component.validationErrors = { description: ['Error message'] };
+    expect(component.hasDescriptionError()).toBeTrue();
+  });
+
+  it('getDescriptionErrors should return empty array when no errors', () => {
+    component.validationErrors = {};
+    expect(component.getDescriptionErrors()).toEqual([]);
+  });
+
+  it('getDescriptionErrors should return errors for Description key', () => {
+    component.validationErrors = { Description: ['Error 1', 'Error 2'] };
+    expect(component.getDescriptionErrors()).toEqual(['Error 1', 'Error 2']);
+  });
+
+  it('getDescriptionErrors should return errors for description key (lowercase)', () => {
+    component.validationErrors = { description: ['Error message'] };
+    expect(component.getDescriptionErrors()).toEqual(['Error message']);
   });
 });

--- a/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.ts
+++ b/src/Presentation/webapp/src/app/components/add-container-modal/add-container-modal.component.ts
@@ -18,13 +18,17 @@ export class AddContainerModalComponent {
   isVisible = false;
   isSubmitting = false;
   containerName = '';
+  containerDescription = '';
   validationErrors: { [key: string]: string[] } = {};
   generalError: string | null = null;
+
+  readonly descriptionMaxLength = 250;
 
   constructor(private containerService: ContainerService) {}
 
   open(): void {
     this.containerName = '';
+    this.containerDescription = '';
     this.validationErrors = {};
     this.generalError = null;
     this.isSubmitting = false;
@@ -43,7 +47,7 @@ export class AddContainerModalComponent {
 
     const request: CreateContainerRequest = {
       name: this.containerName,
-      description: ''
+      description: this.containerDescription
     };
 
     this.containerService.create(request).subscribe({
@@ -71,5 +75,13 @@ export class AddContainerModalComponent {
 
   getNameErrors(): string[] {
     return this.validationErrors['Name'] || this.validationErrors['name'] || [];
+  }
+
+  hasDescriptionError(): boolean {
+    return !!this.validationErrors['Description'] || !!this.validationErrors['description'];
+  }
+
+  getDescriptionErrors(): string[] {
+    return this.validationErrors['Description'] || this.validationErrors['description'] || [];
   }
 }


### PR DESCRIPTION
Closes #61

## Summary
Adds an optional description field to the container creation modal.

## Changes
- **Backend**: Added description validation in `CreateContainerCommandHandler`:
  - Maximum 250 characters
  - Trims leading/trailing whitespace
- **Frontend**: Added description textarea to the "Add Container" modal:
  - Multi-line input with 250 character limit
  - Character counter displayed below the field
  - Optional field (not required)
- **Tests**: Added unit tests and Angular tests for the new functionality