### PR TITLE
Standardize buttons to use color-filled variants

### DIFF
--- a/src/Presentation/webapp/src/app/components/home/home.component.html
+++ b/src/Presentation/webapp/src/app/components/home/home.component.html
@@ -31,7 +31,7 @@
         aria-label="Filter containers by name">
       @if (searchText) {
         <button
-          class="btn btn-outline-secondary"
+          class="btn btn-secondary"
           type="button"
           (click)="clearSearch()"
           aria-label="Clear search">
@@ -88,7 +88,7 @@
           <td>{{ container.name }}</td>
           <td>
             <button 
-              class="btn btn-outline-primary btn-sm me-1" 
+              class="btn btn-primary btn-sm me-1" 
               type="button" 
               (click)="openEditModal(container)"
               title="Edit container"
@@ -98,7 +98,7 @@
               </svg>
             </button>
             <button 
-              class="btn btn-outline-danger btn-sm" 
+              class="btn btn-danger btn-sm" 
               type="button" 
               (click)="openDeleteModal(container)"
               title="Delete container"

--- a/src/Presentation/webapp/src/app/components/home/home.component.spec.ts
+++ b/src/Presentation/webapp/src/app/components/home/home.component.spec.ts
@@ -140,7 +140,7 @@ describe('HomeComponent', () => {
     fixture.detectChanges();
     
     const compiled = fixture.nativeElement as HTMLElement;
-    const deleteButtons = compiled.querySelectorAll('button.btn-outline-danger');
+    const deleteButtons = compiled.querySelectorAll('button.btn-danger');
     expect(deleteButtons.length).toBe(2);
   }));
 


### PR DESCRIPTION
## Summary

- Replace outline button styling (`btn-outline-*`) with filled variants (`btn-*`) for visual consistency
- Update Clear search button: `btn-outline-secondary` → `btn-secondary`
- Update Edit button: `btn-outline-primary` → `btn-primary`
- Update Delete button: `btn-outline-danger` → `btn-danger`
- Update test selector in `home.component.spec.ts` to match new `btn-danger` class

## Test plan

- [x] All 96 Angular tests pass
- [x] No `btn-outline-*` classes remain in the codebase (except `btn-close`)
- [x] Verify Edit buttons use `btn-primary` class
- [x] Verify Delete buttons use `btn-danger` class
- [x] Verify utility buttons use `btn-secondary` class

Closes #111

Made with [Cursor](https://cursor.com)