### PR TITLE
Standardize buttons to use color-filled variants

### DIFF
--- a/src/Presentation/webapp/src/app/components/breadcrumb/breadcrumb.component.html
+++ b/src/Presentation/webapp/src/app/components/breadcrumb/breadcrumb.component.html
@@ -1,0 +1,15 @@
+<nav aria-label="breadcrumb" class="breadcrumb-nav">
+  <div class="container">
+    <ol class="breadcrumb mb-0">
+      @for (item of breadcrumbs; track item.label) {
+        <li class="breadcrumb-item" [class.active]="item.active" [attr.aria-current]="item.active ? 'page' : null">
+          @if (item.active) {
+            <span>{{ item.label }}</span>
+          } @else {
+            <a [routerLink]="item.url">{{ item.label }}</a>
+          }
+        </li>
+      }
+    </ol>
+  </div>
+</nav>

--- a/src/Presentation/webapp/src/app/components/breadcrumb/breadcrumb.component.scss
+++ b/src/Presentation/webapp/src/app/components/breadcrumb/breadcrumb.component.scss
@@ -1,0 +1,23 @@
+.breadcrumb-nav {
+  background-color: #f8f9fa;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid #dee2e6;
+}
+
+.breadcrumb {
+  font-size: 0.875rem;
+
+  a {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  .breadcrumb-item {
+    &.active {
+      color: #6c757d;
+    }
+  }
+}

--- a/src/Presentation/webapp/src/app/components/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/Presentation/webapp/src/app/components/breadcrumb/breadcrumb.component.spec.ts
@@ -1,0 +1,127 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { Location } from '@angular/common';
+import { provideRouter } from '@angular/router';
+
+import { BreadcrumbComponent } from './breadcrumb.component';
+import { BreadcrumbService } from '../../services/breadcrumb.service';
+import { HomeComponent } from '../home/home.component';
+import { ContainerDetailsComponent } from '../container-details/container-details.component';
+
+describe('BreadcrumbComponent', () => {
+  let component: BreadcrumbComponent;
+  let fixture: ComponentFixture<BreadcrumbComponent>;
+  let router: Router;
+  let location: Location;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BreadcrumbComponent],
+      providers: [
+        provideRouter([
+          { path: '', component: HomeComponent },
+          { path: 'containers/:id', component: ContainerDetailsComponent }
+        ])
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BreadcrumbComponent);
+    component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+    location = TestBed.inject(Location);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display "Containers" on home route', async () => {
+    await router.navigate(['/']);
+    fixture.detectChanges();
+
+    expect(component.breadcrumbs.length).toBe(1);
+    expect(component.breadcrumbs[0].label).toBe('Containers');
+    expect(component.breadcrumbs[0].active).toBeTrue();
+  });
+
+  it('should display "Containers > Container [id]" on container details route', async () => {
+    await router.navigate(['/containers/1']);
+    fixture.detectChanges();
+
+    expect(component.breadcrumbs.length).toBe(2);
+    expect(component.breadcrumbs[0].label).toBe('Containers');
+    expect(component.breadcrumbs[0].active).toBeFalse();
+    expect(component.breadcrumbs[1].label).toContain('Container');
+    expect(component.breadcrumbs[1].active).toBeTrue();
+  });
+
+  it('should make "Containers" link clickable on details page', async () => {
+    await router.navigate(['/containers/1']);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const containersLink = compiled.querySelector('a');
+    expect(containersLink).toBeTruthy();
+    expect(containersLink?.textContent?.trim()).toBe('Containers');
+  });
+
+  it('should mark current page as active with aria-current', async () => {
+    await router.navigate(['/']);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const activeItem = compiled.querySelector('.breadcrumb-item.active');
+    expect(activeItem).toBeTruthy();
+    expect(activeItem?.getAttribute('aria-current')).toBe('page');
+  });
+
+  it('should not have link on current page', async () => {
+    await router.navigate(['/']);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const links = compiled.querySelectorAll('a');
+    expect(links.length).toBe(0);
+  });
+
+  it('should have aria-label for accessibility', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    const nav = compiled.querySelector('nav');
+    expect(nav?.getAttribute('aria-label')).toBe('breadcrumb');
+  });
+
+  it('should update breadcrumbs on navigation', async () => {
+    // Start at home
+    await router.navigate(['/']);
+    fixture.detectChanges();
+    expect(component.breadcrumbs.length).toBe(1);
+
+    // Navigate to details
+    await router.navigate(['/containers/1']);
+    fixture.detectChanges();
+    expect(component.breadcrumbs.length).toBe(2);
+
+    // Navigate back to home
+    await router.navigate(['/']);
+    fixture.detectChanges();
+    expect(component.breadcrumbs.length).toBe(1);
+  });
+
+  it('should display container name from service', async () => {
+    const breadcrumbService = TestBed.inject(BreadcrumbService);
+
+    await router.navigate(['/containers/1']);
+    fixture.detectChanges();
+
+    // Initially shows fallback "Container 1"
+    expect(component.breadcrumbs[1].label).toContain('Container');
+
+    // Set container name via service
+    breadcrumbService.setBreadcrumbData({ containerName: 'My Test Container' });
+    fixture.detectChanges();
+
+    // Should now show actual container name
+    expect(component.breadcrumbs[1].label).toBe('My Test Container');
+  });
+});

--- a/src/Presentation/webapp/src/app/components/breadcrumb/breadcrumb.component.ts
+++ b/src/Presentation/webapp/src/app/components/breadcrumb/breadcrumb.component.ts
@@ -1,0 +1,99 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router, ActivatedRoute, NavigationEnd, RouterModule } from '@angular/router';
+import { filter, Subject, takeUntil, combineLatest } from 'rxjs';
+import { BreadcrumbService, BreadcrumbData } from '../../services/breadcrumb.service';
+
+interface BreadcrumbItem {
+  label: string;
+  url: string;
+  active: boolean;
+}
+
+@Component({
+  selector: 'app-breadcrumb',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './breadcrumb.component.html',
+  styleUrl: './breadcrumb.component.scss'
+})
+export class BreadcrumbComponent implements OnInit, OnDestroy {
+  breadcrumbs: BreadcrumbItem[] = [];
+  private destroy$ = new Subject<void>();
+  private breadcrumbData: BreadcrumbData = {};
+
+  constructor(
+    private router: Router,
+    private activatedRoute: ActivatedRoute,
+    private breadcrumbService: BreadcrumbService
+  ) {}
+
+  ngOnInit(): void {
+    // Subscribe to breadcrumb data changes
+    this.breadcrumbService.getBreadcrumbData()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(data => {
+        this.breadcrumbData = data;
+        this.buildBreadcrumbs();
+      });
+
+    // Subscribe to router events to rebuild breadcrumbs on navigation
+    this.router.events
+      .pipe(
+        filter(event => event instanceof NavigationEnd),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(() => {
+        this.buildBreadcrumbs();
+      });
+
+    // Build breadcrumbs on init
+    this.buildBreadcrumbs();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private buildBreadcrumbs(): void {
+    const url = this.router.url;
+    this.breadcrumbs = [];
+
+    if (url === '/' || url === '') {
+      // Home page - just "Containers" (active/not clickable)
+      this.breadcrumbs.push({
+        label: 'Containers',
+        url: '/',
+        active: true
+      });
+    } else if (url.startsWith('/containers/')) {
+      // Container details page - "Containers > [Container Name]"
+      this.breadcrumbs.push({
+        label: 'Containers',
+        url: '/',
+        active: false
+      });
+
+      // Get container name from route data or use placeholder
+      const containerName = this.getContainerName();
+      this.breadcrumbs.push({
+        label: containerName,
+        url: '',
+        active: true
+      });
+    }
+  }
+
+  private getContainerName(): string {
+    // Use container name from breadcrumb service if available
+    if (this.breadcrumbData.containerName) {
+      return this.breadcrumbData.containerName;
+    }
+
+    // Fallback to extracting ID from URL
+    const segments = this.router.url.split('/');
+    const containerId = segments[segments.length - 1];
+    return `Container ${containerId}`;
+  }
+}

--- a/src/Presentation/webapp/src/app/components/container-details/container-details.component.html
+++ b/src/Presentation/webapp/src/app/components/container-details/container-details.component.html
@@ -1,0 +1,101 @@
+@if (isLoading) {
+  <div class="d-flex justify-content-center">
+    <div class="spinner-border" role="status">
+      <span class="visually-hidden">Loading...</span>
+    </div>
+  </div>
+} @else if (notFound) {
+  <div class="alert alert-danger" role="alert">
+    <h4 class="alert-heading">Container not found</h4>
+    <p>The container you're looking for doesn't exist.</p>
+    <hr>
+    <a routerLink="/" class="btn btn-primary">← Back to Containers</a>
+  </div>
+} @else if (container) {
+  <!-- Header with name and action buttons -->
+  <div class="d-flex justify-content-between align-items-center flex-wrap mb-3">
+    <h1>{{ container.name }}</h1>
+    <div>
+      <button
+        class="btn btn-primary me-2"
+        type="button"
+        (click)="openEditModal()"
+        aria-label="Edit container">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+          <path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168l10-10zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207 11.207 2.5zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293l6.5-6.5zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/>
+        </svg>
+        Edit
+      </button>
+      <button
+        class="btn btn-danger"
+        type="button"
+        (click)="openDeleteModal()"
+        aria-label="Delete container">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+          <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z"/>
+          <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z"/>
+        </svg>
+        Delete
+      </button>
+    </div>
+  </div>
+
+  <!-- Description -->
+  <p class="text-muted">{{ container.description }}</p>
+
+  <h2 class="mt-4">Container Items</h2>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Item ID</th>
+        <th>Name</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td colspan="2" class="text-center text-muted">No items in this container</td>
+      </tr>
+    </tbody>
+  </table>
+}
+
+<!-- Edit Container Modal -->
+<app-edit-container-modal
+  #editContainerModal
+  (containerUpdated)="onContainerUpdated($event)">
+</app-edit-container-modal>
+
+<!-- Delete Confirmation Modal -->
+@if (isDeleteModalVisible && container) {
+  <div class="modal fade show" id="deleteContainerModal" tabindex="-1" style="display: block;" aria-labelledby="deleteContainerModalLabel" aria-modal="true" role="dialog">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="deleteContainerModalLabel">Delete Container</h5>
+          <button type="button" class="btn-close" (click)="closeDeleteModal()" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <p>Are you sure you want to delete the container <strong>{{ container.name }}</strong>?</p>
+          <p class="text-muted">This action cannot be undone.</p>
+          @if (generalError) {
+            <div class="alert alert-danger" role="alert">
+              {{ generalError }}
+            </div>
+          }
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" (click)="closeDeleteModal()">Cancel</button>
+          <button type="button" class="btn btn-danger" (click)="confirmDelete()" [disabled]="isDeleting">
+            @if (isDeleting) {
+              <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+              <span>Deleting...</span>
+            } @else {
+              <span>Delete</span>
+            }
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="modal-backdrop fade show"></div>
+}

--- a/src/Presentation/webapp/src/app/components/container-details/container-details.component.scss
+++ b/src/Presentation/webapp/src/app/components/container-details/container-details.component.scss
@@ -1,0 +1,1 @@
+// Container details styles

--- a/src/Presentation/webapp/src/app/components/container-details/container-details.component.spec.ts
+++ b/src/Presentation/webapp/src/app/components/container-details/container-details.component.spec.ts
@@ -1,0 +1,278 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { Title } from '@angular/platform-browser';
+import { provideRouter, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
+
+import { ContainerDetailsComponent } from './container-details.component';
+import { ContainerService } from '../../services/container.service';
+import { environment } from '../../../environments/environment';
+import { of } from 'rxjs';
+
+describe('ContainerDetailsComponent', () => {
+  let component: ContainerDetailsComponent;
+  let fixture: ComponentFixture<ContainerDetailsComponent>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ContainerDetailsComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        ContainerService,
+        Title,
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: () => '1'
+              }
+            }
+          }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ContainerDetailsComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should show loading spinner initially', () => {
+    expect(component.isLoading).toBeTrue();
+    const compiled = fixture.nativeElement as HTMLElement;
+    fixture.detectChanges();
+    expect(compiled.querySelector('.spinner-border')).toBeTruthy();
+
+    // Complete the HTTP request
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers/1`);
+    req.flush({ containerId: 1, name: 'Test Container', description: 'Test Description' });
+  });
+
+  it('should display container details when loaded', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers/1`);
+    req.flush({ containerId: 1, name: 'Test Container', description: 'Test Description' });
+
+    tick();
+    fixture.detectChanges();
+
+    expect(component.isLoading).toBeFalse();
+    expect(component.container).toBeTruthy();
+    expect(component.container?.name).toBe('Test Container');
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('h1')?.textContent).toContain('Test Container');
+    expect(compiled.textContent).toContain('Test Description');
+  }));
+
+  it('should display empty state for items table when container has no items', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers/1`);
+    req.flush({ containerId: 1, name: 'Test Container', description: 'Test Description', inventoryItems: [] });
+
+    tick();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('No items in this container');
+  }));
+
+  it('should display not found message when container does not exist', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers/1`);
+    req.flush(null, { status: 404, statusText: 'Not Found' });
+
+    tick();
+    fixture.detectChanges();
+
+    expect(component.isLoading).toBeFalse();
+    expect(component.notFound).toBeTrue();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Container not found');
+  }));
+
+  it('should set page title with container name', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers/1`);
+    req.flush({ containerId: 1, name: 'My Container', description: 'Test Description' });
+
+    tick();
+
+    const titleService = TestBed.inject(Title);
+    expect(titleService.getTitle()).toBe('My Container - Ivan');
+  }));
+
+  it('should not display back link in success state', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers/1`);
+    req.flush({ containerId: 1, name: 'Test Container', description: 'Test Description' });
+
+    tick();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const backLink = compiled.querySelector('a[routerLink="/"]');
+    expect(backLink).toBeNull();
+  }));
+
+  it('should show edit and delete buttons when container loaded', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers/1`);
+    req.flush({ containerId: 1, name: 'Test Container', description: 'Test Description' });
+
+    tick();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const editButton = compiled.querySelector('button[aria-label="Edit container"]');
+    const deleteButton = compiled.querySelector('button[aria-label="Delete container"]');
+
+    expect(editButton).toBeTruthy();
+    expect(deleteButton).toBeTruthy();
+  }));
+
+  it('should open edit modal when edit button clicked', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers/1`);
+    const testContainer = { containerId: 1, name: 'Test Container', description: 'Test Description' };
+    req.flush(testContainer);
+
+    tick();
+    fixture.detectChanges();
+
+    spyOn(component.editContainerModal, 'open');
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const editButton = compiled.querySelector('button[aria-label="Edit container"]') as HTMLButtonElement;
+    editButton.click();
+
+    expect(component.editContainerModal.open).toHaveBeenCalledWith(testContainer);
+  }));
+
+  it('should update container when modal emits containerUpdated', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers/1`);
+    req.flush({ containerId: 1, name: 'Test Container', description: 'Test Description' });
+
+    tick();
+    fixture.detectChanges();
+
+    const updatedContainer = { containerId: 1, name: 'Updated Container', description: 'Updated Description' };
+    component.onContainerUpdated(updatedContainer);
+
+    expect(component.container?.name).toBe('Updated Container');
+    expect(component.container?.description).toBe('Updated Description');
+
+    const titleService = TestBed.inject(Title);
+    expect(titleService.getTitle()).toBe('Updated Container - Ivan');
+  }));
+
+  it('should open delete modal when delete button clicked', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers/1`);
+    req.flush({ containerId: 1, name: 'Test Container', description: 'Test Description' });
+
+    tick();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const deleteButton = compiled.querySelector('button[aria-label="Delete container"]') as HTMLButtonElement;
+    deleteButton.click();
+
+    fixture.detectChanges();
+
+    expect(component.isDeleteModalVisible).toBeTrue();
+
+    const modal = compiled.querySelector('#deleteContainerModal');
+    expect(modal).toBeTruthy();
+  }));
+
+  it('should close delete modal when cancel clicked', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers/1`);
+    req.flush({ containerId: 1, name: 'Test Container', description: 'Test Description' });
+
+    tick();
+    fixture.detectChanges();
+
+    component.openDeleteModal();
+    fixture.detectChanges();
+
+    expect(component.isDeleteModalVisible).toBeTrue();
+
+    component.closeDeleteModal();
+    fixture.detectChanges();
+
+    expect(component.isDeleteModalVisible).toBeFalse();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const modal = compiled.querySelector('#deleteContainerModal');
+    expect(modal).toBeNull();
+  }));
+
+  it('should delete container and navigate to home on confirm', fakeAsync(() => {
+    const router = TestBed.inject(Router);
+    spyOn(router, 'navigate');
+
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers/1`);
+    req.flush({ containerId: 1, name: 'Test Container', description: 'Test Description' });
+
+    tick();
+    fixture.detectChanges();
+
+    component.openDeleteModal();
+    component.confirmDelete();
+
+    const deleteReq = httpMock.expectOne(`${environment.apiUrl}/api/containers/1`);
+    expect(deleteReq.request.method).toBe('DELETE');
+
+    deleteReq.flush(null);
+
+    tick();
+
+    expect(router.navigate).toHaveBeenCalledWith(['/']);
+  }));
+
+  it('should not show edit/delete buttons when container not found', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers/1`);
+    req.flush(null, { status: 404, statusText: 'Not Found' });
+
+    tick();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const editButton = compiled.querySelector('button[aria-label="Edit container"]');
+    const deleteButton = compiled.querySelector('button[aria-label="Delete container"]');
+
+    expect(editButton).toBeNull();
+    expect(deleteButton).toBeNull();
+  }));
+});

--- a/src/Presentation/webapp/src/app/components/container-details/container-details.component.ts
+++ b/src/Presentation/webapp/src/app/components/container-details/container-details.component.ts
@@ -1,0 +1,108 @@
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { Title } from '@angular/platform-browser';
+import { ContainerService } from '../../services/container.service';
+import { ContainerResponse, ValidationProblemDetails } from '../../models/container.model';
+import { BreadcrumbService } from '../../services/breadcrumb.service';
+import { EditContainerModalComponent } from '../edit-container-modal/edit-container-modal.component';
+
+@Component({
+  selector: 'app-container-details',
+  standalone: true,
+  imports: [CommonModule, RouterModule, EditContainerModalComponent],
+  templateUrl: './container-details.component.html',
+  styleUrl: './container-details.component.scss'
+})
+export class ContainerDetailsComponent implements OnInit, OnDestroy {
+  @ViewChild('editContainerModal') editContainerModal!: EditContainerModalComponent;
+
+  container: ContainerResponse | null = null;
+  isLoading = true;
+  notFound = false;
+
+  // Delete modal properties
+  isDeleteModalVisible = false;
+  isDeleting = false;
+  generalError = '';
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private containerService: ContainerService,
+    private titleService: Title,
+    private breadcrumbService: BreadcrumbService
+  ) {}
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id) {
+      this.loadContainer(+id);
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.breadcrumbService.clearBreadcrumbData();
+  }
+
+  loadContainer(id: number): void {
+    this.isLoading = true;
+    this.containerService.getById(id).subscribe({
+      next: (container) => {
+        this.container = container;
+        this.titleService.setTitle(`${container.name} - Ivan`);
+        this.breadcrumbService.setBreadcrumbData({ containerName: container.name });
+        this.isLoading = false;
+      },
+      error: (error) => {
+        this.notFound = true;
+        this.isLoading = false;
+        this.titleService.setTitle('Container Not Found - Ivan');
+      }
+    });
+  }
+
+  openEditModal(): void {
+    if (!this.container) return;
+    this.editContainerModal.open(this.container);
+  }
+
+  onContainerUpdated(updated: ContainerResponse): void {
+    this.container = updated;
+    this.titleService.setTitle(`${updated.name} - Ivan`);
+    this.breadcrumbService.setBreadcrumbData({ containerName: updated.name });
+  }
+
+  openDeleteModal(): void {
+    this.isDeleteModalVisible = true;
+    this.generalError = '';
+  }
+
+  closeDeleteModal(): void {
+    this.isDeleteModalVisible = false;
+    this.generalError = '';
+  }
+
+  confirmDelete(): void {
+    if (!this.container) return;
+
+    this.isDeleting = true;
+    this.generalError = '';
+
+    this.containerService.delete(this.container.containerId).subscribe({
+      next: () => {
+        // Navigate to containers list on success
+        this.router.navigate(['/']);
+      },
+      error: (error: ValidationProblemDetails) => {
+        this.isDeleting = false;
+
+        if (error.title) {
+          this.generalError = error.title;
+        } else {
+          this.generalError = 'Failed to delete container. Please try again.';
+        }
+      }
+    });
+  }
+}

--- a/src/Presentation/webapp/src/app/components/home/home.component.html
+++ b/src/Presentation/webapp/src/app/components/home/home.component.html
@@ -31,7 +31,7 @@
         aria-label="Filter containers by name">
       @if (searchText) {
         <button
-          class="btn btn-outline-secondary"
+          class="btn btn-secondary"
           type="button"
           (click)="clearSearch()"
           aria-label="Clear search">
@@ -88,7 +88,7 @@
           <td>{{ container.name }}</td>
           <td>
             <button 
-              class="btn btn-outline-primary btn-sm me-1" 
+              class="btn btn-primary btn-sm me-1" 
               type="button" 
               (click)="openEditModal(container)"
               title="Edit container"
@@ -98,7 +98,7 @@
               </svg>
             </button>
             <button 
-              class="btn btn-outline-danger btn-sm" 
+              class="btn btn-danger btn-sm" 
               type="button" 
               (click)="openDeleteModal(container)"
               title="Delete container"

--- a/src/Presentation/webapp/src/app/components/home/home.component.spec.ts
+++ b/src/Presentation/webapp/src/app/components/home/home.component.spec.ts
@@ -140,7 +140,7 @@ describe('HomeComponent', () => {
     fixture.detectChanges();
     
     const compiled = fixture.nativeElement as HTMLElement;
-    const deleteButtons = compiled.querySelectorAll('button.btn-outline-danger');
+    const deleteButtons = compiled.querySelectorAll('button.btn-danger');
     expect(deleteButtons.length).toBe(2);
   }));
 

--- a/src/Presentation/webapp/src/app/services/breadcrumb.service.spec.ts
+++ b/src/Presentation/webapp/src/app/services/breadcrumb.service.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed } from '@angular/core/testing';
+import { BreadcrumbService } from './breadcrumb.service';
+
+describe('BreadcrumbService', () => {
+  let service: BreadcrumbService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(BreadcrumbService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should emit empty data initially', (done) => {
+    service.getBreadcrumbData().subscribe(data => {
+      expect(data).toEqual({});
+      done();
+    });
+  });
+
+  it('should update breadcrumb data', (done) => {
+    const testData = { containerName: 'Test Container' };
+    let firstCall = true;
+
+    service.getBreadcrumbData().subscribe(data => {
+      if (firstCall) {
+        firstCall = false;
+        return;
+      }
+      expect(data).toEqual(testData);
+      done();
+    });
+
+    service.setBreadcrumbData(testData);
+  });
+
+  it('should clear breadcrumb data', (done) => {
+    let callCount = 0;
+    service.getBreadcrumbData().subscribe(data => {
+      callCount++;
+      // Skip first emission (initial empty {})
+      if (callCount === 1) return;
+      // Skip second emission (set data)
+      if (callCount === 2) return;
+      // Third emission should be cleared data
+      if (callCount === 3) {
+        expect(data).toEqual({});
+        done();
+      }
+    });
+
+    service.setBreadcrumbData({ containerName: 'Test Container' });
+    service.clearBreadcrumbData();
+  });
+});

--- a/src/Presentation/webapp/src/app/services/breadcrumb.service.ts
+++ b/src/Presentation/webapp/src/app/services/breadcrumb.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+export interface BreadcrumbData {
+  containerName?: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BreadcrumbService {
+  private breadcrumbData$ = new BehaviorSubject<BreadcrumbData>({});
+
+  setBreadcrumbData(data: BreadcrumbData): void {
+    this.breadcrumbData$.next(data);
+  }
+
+  getBreadcrumbData(): Observable<BreadcrumbData> {
+    return this.breadcrumbData$.asObservable();
+  }
+
+  clearBreadcrumbData(): void {
+    this.breadcrumbData$.next({});
+  }
+}


### PR DESCRIPTION
## Summary

- Standardize all action buttons to use color-filled Bootstrap button variants instead of outline variants
- Change `btn-outline-secondary` → `btn-secondary` for Clear search button
- Change `btn-outline-primary` → `btn-primary` for Edit buttons  
- Change `btn-outline-danger` → `btn-danger` for Delete buttons
- Update test selector in home.component.spec.ts to match new button class
- Copy missing components (breadcrumb, container-details) and breadcrumb service from WebApp to webapp to fix case-sensitivity build issue on Linux

## Test plan

- [x] All Edit buttons use `btn-primary` class
- [x] All Delete buttons use `btn-danger` class  
- [x] All utility buttons (Clear search) use `btn-secondary` class
- [x] No `btn-outline-*` classes remain in webapp folder
- [x] `build_and_test.ps1` passes (96 unit tests, integration tests, 123 Angular tests)

Closes #129

Made with [Cursor](https://cursor.com)