### PR TITLE
[Work Item #136] Standardize buttons to use color-filled variants

### DIFF
--- a/src/Presentation/WebApp/src/app/components/container-details/container-details.component.html
+++ b/src/Presentation/WebApp/src/app/components/container-details/container-details.component.html
@@ -17,7 +17,7 @@
     <h1>{{ container.name }}</h1>
     <div>
       <button
-        class="btn btn-outline-primary me-2"
+        class="btn btn-primary me-2"
         type="button"
         (click)="openEditModal()"
         aria-label="Edit container">
@@ -27,7 +27,7 @@
         Edit
       </button>
       <button
-        class="btn btn-outline-danger"
+        class="btn btn-danger"
         type="button"
         (click)="openDeleteModal()"
         aria-label="Delete container">

--- a/src/Presentation/WebApp/src/app/components/container-details/container-details.component.spec.ts
+++ b/src/Presentation/WebApp/src/app/components/container-details/container-details.component.spec.ts
@@ -275,4 +275,32 @@ describe('ContainerDetailsComponent', () => {
     expect(editButton).toBeNull();
     expect(deleteButton).toBeNull();
   }));
+
+  it('should render Edit button with btn-primary class', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers/1`);
+    req.flush({ containerId: 1, name: 'Test Container', description: 'Test Description' });
+
+    tick();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const editButton = compiled.querySelector('button.btn-primary[aria-label="Edit container"]');
+    expect(editButton).toBeTruthy();
+  }));
+
+  it('should render Delete button with btn-danger class', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers/1`);
+    req.flush({ containerId: 1, name: 'Test Container', description: 'Test Description' });
+
+    tick();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const deleteButton = compiled.querySelector('button.btn-danger[aria-label="Delete container"]');
+    expect(deleteButton).toBeTruthy();
+  }));
 });

--- a/src/Presentation/webapp/src/app/components/home/home.component.html
+++ b/src/Presentation/webapp/src/app/components/home/home.component.html
@@ -31,7 +31,7 @@
         aria-label="Filter containers by name">
       @if (searchText) {
         <button
-          class="btn btn-outline-secondary"
+          class="btn btn-secondary"
           type="button"
           (click)="clearSearch()"
           aria-label="Clear search">
@@ -88,7 +88,7 @@
           <td>{{ container.name }}</td>
           <td>
             <button 
-              class="btn btn-outline-primary btn-sm me-1" 
+              class="btn btn-primary btn-sm me-1" 
               type="button" 
               (click)="openEditModal(container)"
               title="Edit container"
@@ -98,7 +98,7 @@
               </svg>
             </button>
             <button 
-              class="btn btn-outline-danger btn-sm" 
+              class="btn btn-danger btn-sm" 
               type="button" 
               (click)="openDeleteModal(container)"
               title="Delete container"

--- a/src/Presentation/webapp/src/app/components/home/home.component.spec.ts
+++ b/src/Presentation/webapp/src/app/components/home/home.component.spec.ts
@@ -140,7 +140,7 @@ describe('HomeComponent', () => {
     fixture.detectChanges();
     
     const compiled = fixture.nativeElement as HTMLElement;
-    const deleteButtons = compiled.querySelectorAll('button.btn-outline-danger');
+    const deleteButtons = compiled.querySelectorAll('button.btn-danger');
     expect(deleteButtons.length).toBe(2);
   }));
 
@@ -427,5 +427,57 @@ describe('HomeComponent', () => {
 
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.textContent).toContain('No containers found matching');
+  }));
+
+  it('should render Edit buttons with btn-primary class', fakeAsync(() => {
+    const mockContainers = [
+      { containerId: 1, name: 'Container 1', description: '' },
+      { containerId: 2, name: 'Container 2', description: '' }
+    ];
+
+    fixture.detectChanges();
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers`);
+    req.flush(mockContainers);
+    tick();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const editButtons = compiled.querySelectorAll('button.btn-primary.btn-sm');
+    expect(editButtons.length).toBe(2);
+  }));
+
+  it('should render Delete buttons with btn-danger class', fakeAsync(() => {
+    const mockContainers = [
+      { containerId: 1, name: 'Container 1', description: '' },
+      { containerId: 2, name: 'Container 2', description: '' }
+    ];
+
+    fixture.detectChanges();
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers`);
+    req.flush(mockContainers);
+    tick();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const deleteButtons = compiled.querySelectorAll('button.btn-danger.btn-sm');
+    expect(deleteButtons.length).toBe(2);
+  }));
+
+  it('should render Clear search button with btn-secondary class', fakeAsync(() => {
+    const mockContainers = [
+      { containerId: 1, name: 'Container 1', description: '' }
+    ];
+
+    fixture.detectChanges();
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/containers`);
+    req.flush(mockContainers);
+    tick();
+
+    component.searchText = 'test';
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const clearButton = compiled.querySelector('button.btn-secondary[aria-label="Clear search"]');
+    expect(clearButton).toBeTruthy();
   }));
 });


### PR DESCRIPTION
Closes #136

## Conceptual Definition

**Goal:** Standardize all action buttons to use color-filled Bootstrap button variants instead of outline variants for visual consistency.

**UX:**

* Change `btn-outline-primary` -> `btn-primary` for Edit buttons
* Change `btn-outline-danger` -> `btn-danger` for Delete buttons
* Change `btn-outline-secondary` -> `btn-secondary` for Clear/utility buttons
* Maintain existing filled button styling for modals (already consistent)

**Authorization:** None (Public)

**Validation:** N/A - styling only

**Acceptance Criteria:**

* All Edit buttons use `btn-primary` class
* All Delete buttons use `btn-danger` class
* All utility buttons (like Clear search) use `btn-secondary` class
* No `btn-outline-*` classes remain in the codebase (except close buttons which use `btn-close`)

## User Experience Design

**User Flow:**
1. User views containers list page with existing Edit/Delete buttons in table rows
2. System displays buttons with consistent filled color variants (Edit: blue, Delete: red, Clear search: gray)
3. User views container details page with Edit/Delete buttons in header
4. System displays buttons with consistent filled color variants (Edit: blue, Delete: red)
5. User searches containers and uses Clear search button
6. System displays Clear button with consistent filled gray variant
7. User interacts with modals (Add/Edit/Delete containers)
8. System displays modal action buttons with consistent filled color variants (already implemented)

**UI Components:**
- Modified: Edit buttons (home.component.html lines 91-99, container-details.component.html lines 20-28) - change from `btn-outline-primary` to `btn-primary`
- Modified: Delete buttons (home.component.html lines 100-110, container-details.component.html lines 29-39) - change from `btn-outline-danger` to `btn-danger`
- Modified: Clear search button (home.component.html lines 33-42) - change from `btn-outline-secondary` to `btn-secondary`
- Unmodified: Modal buttons (add-container-modal, edit-container-modal, delete-container-modal) - already use filled variants
- Unmodified: Close buttons (btn-close) - remain unchanged per acceptance criteria

**Error States:**
N/A - This is a styling-only change with no impact on error handling or validation logic

**Accessibility:**
- Color contrast ratios improve with filled buttons (better visibility for users with low vision)
- Button functionality remains unchanged - existing keyboard navigation (Tab, Enter, Space) still works
- Screen readers continue to announce button labels correctly via aria-label attributes
- Focus indicators remain consistent with Bootstrap defaults for filled buttons
- No changes to ARIA attributes or semantic HTML structure required

## Technical Design

**Affected Components:**

| Layer | File | Action |
|-------|------|--------|
| Presentation | `src/Presentation/WebApp/src/app/components/home/home.component.html` | Modify |
| Presentation | `src/Presentation/WebApp/src/app/components/container-details/container-details.component.html` | Modify |

**Implementation Steps:**
1. Update `src/Presentation/WebApp/src/app/components/home/home.component.html` line 34 - Change Clear search button class from `btn-outline-secondary` to `btn-secondary`
2. Update `src/Presentation/WebApp/src/app/components/home/home.component.html` line 91 - Change Edit button class from `btn-outline-primary` to `btn-primary`
3. Update `src/Presentation/WebApp/src/app/components/home/home.component.html` line 101 - Change Delete button class from `btn-outline-danger` to `btn-danger`
4. Update `src/Presentation/WebApp/src/app/components/container-details/container-details.component.html` line 20 - Change Edit button class from `btn-outline-primary` to `btn-primary`
5. Update `src/Presentation/WebApp/src/app/components/container-details/container-details.component.html` line 30 - Change Delete button class from `btn-outline-danger` to `btn-danger`

**Dependencies:** None

**Database Migrations:** None

**Tests:**

| Type | Location | Coverage |
|------|----------|----------|
| Unit | N/A | No unit test changes required - styling only |
| Integration | N/A | No integration test changes required - styling only |
| Angular | `src/Presentation/WebApp/src/app/components/home/home.component.spec.ts` | Verify buttons render with correct CSS classes (btn-primary, btn-danger, btn-secondary) |
| Angular | `src/Presentation/WebApp/src/app/components/container-details/container-details.component.spec.ts` | Verify buttons render with correct CSS classes (btn-primary, btn-danger) |

The test design document already exists and is correctly formatted. This is a UI-only styling change (converting button classes from outline to filled variants), which is appropriately covered by Angular component tests rather than acceptance tests.