### PR TITLE
[Work Item #136] Standardize buttons to use color-filled variants

### DIFF
--- a/src/Presentation/WebApp/src/app/components/container-details/container-details.component.html
+++ b/src/Presentation/WebApp/src/app/components/container-details/container-details.component.html
@@ -17,7 +17,7 @@
     <h1>{{ container.name }}</h1>
     <div>
       <button
-        class="btn btn-outline-primary me-2"
+        class="btn btn-primary me-2"
         type="button"
         (click)="openEditModal()"
         aria-label="Edit container">
@@ -27,7 +27,7 @@
         Edit
       </button>
       <button
-        class="btn btn-outline-danger"
+        class="btn btn-danger"
         type="button"
         (click)="openDeleteModal()"
         aria-label="Delete container">

--- a/src/Presentation/webapp/src/app/components/home/home.component.html
+++ b/src/Presentation/webapp/src/app/components/home/home.component.html
@@ -31,7 +31,7 @@
         aria-label="Filter containers by name">
       @if (searchText) {
         <button
-          class="btn btn-outline-secondary"
+          class="btn btn-secondary"
           type="button"
           (click)="clearSearch()"
           aria-label="Clear search">
@@ -88,7 +88,7 @@
           <td>{{ container.name }}</td>
           <td>
             <button 
-              class="btn btn-outline-primary btn-sm me-1" 
+              class="btn btn-primary btn-sm me-1" 
               type="button" 
               (click)="openEditModal(container)"
               title="Edit container"
@@ -98,7 +98,7 @@
               </svg>
             </button>
             <button 
-              class="btn btn-outline-danger btn-sm" 
+              class="btn btn-danger btn-sm" 
               type="button" 
               (click)="openDeleteModal(container)"
               title="Delete container"

--- a/src/Presentation/webapp/src/app/components/home/home.component.spec.ts
+++ b/src/Presentation/webapp/src/app/components/home/home.component.spec.ts
@@ -140,7 +140,7 @@ describe('HomeComponent', () => {
     fixture.detectChanges();
     
     const compiled = fixture.nativeElement as HTMLElement;
-    const deleteButtons = compiled.querySelectorAll('button.btn-outline-danger');
+    const deleteButtons = compiled.querySelectorAll('button.btn-danger');
     expect(deleteButtons.length).toBe(2);
   }));
 


### PR DESCRIPTION
Closes #136

## Conceptual Definition

**Goal:** Standardize all action buttons to use color-filled Bootstrap button variants instead of outline variants for visual consistency.

**UX:**

* Change `btn-outline-primary` -> `btn-primary` for Edit buttons
* Change `btn-outline-danger` -> `btn-danger` for Delete buttons
* Change `btn-outline-secondary` -> `btn-secondary` for Clear/utility buttons
* Maintain existing filled button styling for modals (already consistent)

**Authorization:** None (Public)

**Validation:** N/A - styling only

**Acceptance Criteria:**

* All Edit buttons use `btn-primary` class
* All Delete buttons use `btn-danger` class
* All utility buttons (like Clear search) use `btn-secondary` class
* No `btn-outline-*` classes remain in the codebase (except close buttons which use `btn-close`)

## User Experience Design

**User Flow:**
1. User views containers list page with Edit/Delete action buttons in table rows
2. System displays buttons with new filled color styling (blue Edit, red Delete)
3. User clicks Clear search button with new filled gray styling
4. System clears search input and refreshes container list
5. User navigates to container details page
6. System displays Edit/Delete buttons in header with new filled color styling
7. User interacts with any button (Edit/Delete/Clear)
8. System responds with same behavior as before - only visual appearance has changed

**UI Components:**
- Modified: Edit buttons in home.component.html (table rows, line 91) - Change from `btn-outline-primary` to `btn-primary`
- Modified: Delete buttons in home.component.html (table rows, line 101) - Change from `btn-outline-danger` to `btn-danger`
- Modified: Clear search button in home.component.html (line 34) - Change from `btn-outline-secondary` to `btn-secondary`
- Modified: Edit button in container-details.component.html (header, line 20) - Change from `btn-outline-primary` to `btn-primary`
- Modified: Delete button in container-details.component.html (header, line 30) - Change from `btn-outline-danger` to `btn-danger`
- New: None
- No changes to modal buttons (already using filled variants: btn-primary, btn-danger, btn-secondary)

**Error States:**
N/A - This is a styling-only change with no impact on functionality or error handling

**Accessibility:**
- Keyboard navigation remains unchanged - all buttons retain existing tabindex and keyboard event handlers
- Screen reader experience unchanged - all aria-labels and aria-labelledby attributes remain intact
- Color contrast improved - filled buttons provide better contrast ratios than outline variants (Bootstrap default filled buttons meet WCAG AA standards)
- Focus indicators maintained - Bootstrap's default focus styling applies to filled buttons
- No changes to semantic HTML structure or ARIA attributes

## Technical Design

**Affected Components:**

| Layer | File | Action |
|-------|------|--------|
| Presentation | `src/Presentation/WebApp/src/app/components/home/home.component.html` | Modify |
| Presentation | `src/Presentation/WebApp/src/app/components/container-details/container-details.component.html` | Modify |

**Implementation Steps:**
1. Modify `src/Presentation/WebApp/src/app/components/home/home.component.html` line 34: Change Clear search button from `btn-outline-secondary` to `btn-secondary`
2. Modify `src/Presentation/WebApp/src/app/components/home/home.component.html` line 91: Change Edit button from `btn-outline-primary` to `btn-primary`
3. Modify `src/Presentation/WebApp/src/app/components/home/home.component.html` line 101: Change Delete button from `btn-outline-danger` to `btn-danger`
4. Modify `src/Presentation/WebApp/src/app/components/container-details/container-details.component.html` line 20: Change Edit button from `btn-outline-primary` to `btn-primary`
5. Modify `src/Presentation/WebApp/src/app/components/container-details/container-details.component.html` line 30: Change Delete button from `btn-outline-danger` to `btn-danger`
6. Verify all `btn-outline-*` classes have been removed from HTML templates (except `btn-close` which is unchanged)

**Dependencies:** None

**Database Migrations:** None

**Tests:**

| Type | Location | Coverage |
|------|----------|----------|
| Unit | N/A | No unit tests needed - styling-only change |
| Integration | N/A | No integration tests needed - styling-only change |
| Angular | N/A | No test modifications needed - existing component tests cover button functionality regardless of styling |

## Test Design

**Acceptance Tests:** None required

**Rationale:** UI-only change covered by Angular tests