### PR TITLE
Cancelled checks status

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,387 @@
+name: Deploy
+run-name: "${{ inputs.release_number && format('{0} • Deploy', inputs.release_number) || format('1.4.{0} • Deploy • {1}', github.event.workflow_run.run_number, github.event.workflow_run.head_branch) }}"
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      release_number:
+        description: 'Release version to deploy (must match an existing Integration Build version, e.g. 1.4.394)'
+        required: true
+        type: string
+env:
+  MAJOR_VERSION: 1
+  MINOR_VERSION: 4
+
+jobs:
+  deploy-to-tdd:
+    name: TDD
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success'
+    concurrency:
+      group: deploy-to-tdd-serialized
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+      actions: read
+    environment:
+      name: TDD
+
+    steps:
+      - name: Report TDD status as pending
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: |
+          $sha = "${{ github.event.workflow_run.head_sha }}"
+          $runUrl = "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          gh api "repos/${{ github.repository }}/statuses/$sha" `
+            -f state="pending" `
+            -f target_url="$runUrl" `
+            -f description="TDD deployment in progress" `
+            -f context="Deploy to TDD"
+
+      - uses: actions/checkout@v6.0.1
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set Version
+        shell: pwsh
+        run: |
+          $version = "${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ github.event.workflow_run.run_number }}"
+          "BUILD_BUILDNUMBER=$version" >> $env:GITHUB_ENV
+          "VERSION=$version" >> $env:GITHUB_ENV
+          Write-Host "Build version: $version"
+
+      - name: Create Octopus Release
+        id: create-octopus-release
+        uses: OctopusDeploy/create-release-action@v3
+        env:
+          OCTOPUS_API_KEY: ${{ secrets.OCTO_API_KEY }}
+          OCTOPUS_URL: ${{ secrets.OCTOPUS_URL }}
+          OCTOPUS_SPACE: ${{ vars.OCTOPUS_SPACE }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          BUILD_BUILDNUMBER: ${{ env.VERSION }}
+        with:
+          project: '${{ vars.OCTOPUS_PROJECT }}'
+          release_number: "${{ env.VERSION }}"
+          git_ref: ${{ github.event.workflow_run.head_branch }}
+          git_commit: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Deploy Octopus Release to TDD
+        id: start-deploy-to-tdd
+        uses: OctopusDeploy/deploy-release-action@v3
+        env:
+          OCTOPUS_API_KEY: ${{ secrets.OCTO_API_KEY }}
+          OCTOPUS_URL: ${{ secrets.OCTOPUS_URL }}
+          OCTOPUS_SPACE: ${{ vars.OCTOPUS_SPACE }}
+          BUILD_BUILDNUMBER: ${{ env.VERSION }}
+        with:
+          project: ${{ vars.OCTOPUS_PROJECT }}
+          release_number: ${{ env.VERSION }}
+          environments: "TDD"
+
+      - name: Download Acceptance Test Package
+        uses: actions/download-artifact@v4
+        with:
+          name: churchbulletin-nuget-packages
+          path: ./packages
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Extract Acceptance Test Package
+        shell: pwsh
+        run: |
+          $package = Get-ChildItem -Path ./packages -Filter "ChurchBulletin.AcceptanceTests.*.nupkg" | Select-Object -First 1
+          if (-not $package) {
+            Write-Error "ChurchBulletin.AcceptanceTests package not found"
+            Get-ChildItem -Path ./packages
+            exit 1
+          }
+          Write-Host "Extracting $($package.Name)..."
+          Expand-Archive -Path $package.FullName -DestinationPath ./acceptance-tests -Force
+
+          $testDll = Get-ChildItem -Path ./acceptance-tests -Filter "ClearMeasure.Bootcamp.AcceptanceTests.dll" -Recurse | Select-Object -First 1
+          if (-not $testDll) {
+            Write-Error "ClearMeasure.Bootcamp.AcceptanceTests.dll not found in extracted package"
+            exit 1
+          }
+          Write-Host "Test DLL found at: $($testDll.FullName)"
+          "TEST_DIR=$($testDll.DirectoryName)" >> $env:GITHUB_ENV
+          "TEST_DLL=$($testDll.FullName)" >> $env:GITHUB_ENV
+
+          if ($IsLinux) {
+            chmod -R +x ./acceptance-tests/.playwright/ 2>$null
+            Write-Host "Fixed execute permissions on .playwright/ directory"
+          }
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('src/AcceptanceTests/AcceptanceTests.csproj') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
+      - name: Install Playwright
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $playwrightScript = Join-Path $env:TEST_DIR "playwright.ps1"
+          if (Test-Path $playwrightScript) {
+            Write-Host "Installing Playwright browsers from $playwrightScript"
+            & pwsh $playwrightScript install --with-deps
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to install Playwright browsers"
+            }
+          } else {
+            Write-Warning "Playwright script not found at $playwrightScript"
+          }
+
+      - name: Install Playwright dependencies only
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        shell: pwsh
+        run: |
+          $playwrightScript = Join-Path $env:TEST_DIR "playwright.ps1"
+          if (Test-Path $playwrightScript) {
+            Write-Host "Installing Playwright OS dependencies (browsers cached)"
+            & pwsh $playwrightScript install-deps
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to install Playwright dependencies"
+            }
+          }
+
+      - name: Wait for the TDD deployment to complete
+        uses: OctopusDeploy/await-task-action@v3
+        env:
+          OCTOPUS_API_KEY: ${{ secrets.OCTO_API_KEY  }}
+          OCTOPUS_URL: ${{ secrets.OCTOPUS_URL }}
+          OCTOPUS_SPACE: ${{ vars.OCTOPUS_SPACE }}
+        with:
+          server_task_id: ${{ fromJson(steps.start-deploy-to-tdd.outputs.server_tasks)[0].serverTaskId }}
+          timeout_after: 1800
+
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Get Container App FQDN and Connection String
+        shell: pwsh
+        run: |
+          $appJson = az containerapp show `
+            --name ${{ vars.CONTAINER_APP_NAME }} `
+            --resource-group ${{ vars.TDD_RESOURCE_GROUP_NAME}} `
+            --query "{fqdn: properties.configuration.ingress.fqdn, connStr: properties.template.containers[0].env[?name=='ConnectionStrings__SqlConnectionString'].value | [0]}" `
+            -o json | ConvertFrom-Json
+
+          $containerAppFqdn = $appJson.fqdn
+          if ([string]::IsNullOrWhiteSpace($containerAppFqdn)) {
+            Write-Error "Error: Could not retrieve container app FQDN"
+            exit 1
+          }
+
+          $containerAppUrl = "https://$containerAppFqdn"
+          Write-Host "Container App FQDN: $containerAppFqdn"
+          Write-Host "Container App URL: $containerAppUrl"
+          "CONTAINER_APP_URL=$containerAppUrl" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "ApplicationBaseUrl=$containerAppUrl" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+          $containerAppConnectionString = $appJson.connStr
+          Write-Host "Container App Connection String retrieved: $(-not [string]::IsNullOrWhiteSpace($containerAppConnectionString))"
+          "ConnectionStrings__SqlConnectionString=$containerAppConnectionString" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "CONTAINER_APP_CONNECTION_STRING=$containerAppConnectionString" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Wait for Container App to become healthy
+        shell: pwsh
+        run: |
+          $url = "${{ env.CONTAINER_APP_URL }}/_healthcheck"
+          $maxAttempts = 30
+          $delaySeconds = 5
+          Write-Host "Polling $url for healthy response (max ${maxAttempts} attempts, ${delaySeconds}s apart)..."
+          for ($i = 1; $i -le $maxAttempts; $i++) {
+            try {
+              $response = Invoke-WebRequest -Uri $url -UseBasicParsing -TimeoutSec 15
+              $body = $response.Content
+              Write-Host "Attempt ${i}: HTTP $($response.StatusCode) - $body"
+              if ($response.StatusCode -eq 200 -and $body -match 'Healthy') {
+                Write-Host "Container App is healthy after $i attempts."
+                exit 0
+              }
+              if ($response.StatusCode -eq 200 -and $body -match 'Degraded') {
+                Write-Host "::warning::Container App returned Degraded health status after $i attempts."
+                Write-Host "--- Degraded Health Check Diagnostics ---"
+                Write-Host "Health check response body: $body"
+                Write-Host "Health check HTTP status: $($response.StatusCode)"
+                Write-Host "Health check headers:"
+                $response.Headers.GetEnumerator() | ForEach-Object { Write-Host "  $($_.Key): $($_.Value)" }
+                Write-Host "Container App URL: ${{ env.CONTAINER_APP_URL }}"
+                Write-Host "Timestamp: $(Get-Date -Format o)"
+                Write-Host "--- End Diagnostics ---"
+                exit 0
+              }
+            } catch {
+              Write-Host "Attempt ${i}: $($_.Exception.Message)"
+            }
+            if ($i -lt $maxAttempts) { Start-Sleep -Seconds $delaySeconds }
+          }
+          Write-Error "Container App did not become healthy after $maxAttempts attempts."
+          exit 1
+
+      - name: Run Acceptance tests
+        if: success()
+        shell: pwsh
+        env:
+          ConnectionStrings__SqlConnectionString: ${{ env.CONTAINER_APP_CONNECTION_STRING }}
+          ApplicationBaseUrl: ${{ env.CONTAINER_APP_URL }}
+          StartLocalServer: "false"
+          TEST_INPUT_DELAY_MS: "200"
+          AI_OpenAI_ApiKey: ${{ secrets.AI_OPENAI_APIKEY }}
+          AI_OpenAI_Url: ${{ vars.AI_OPENAI_URL }}
+          AI_OpenAI_Model: ${{ vars.AI_OPENAI_MODEL }}
+        run: |
+          $resultsDirectory = Join-Path (Resolve-Path .) "build/test/AcceptanceTests"
+          New-Item -ItemType Directory -Path $resultsDirectory -Force | Out-Null
+          $runSettingsPath = Join-Path (Resolve-Path .) "src/AcceptanceTests/AcceptanceTests.runsettings"
+
+          Write-Host "Running acceptance tests against $env:ApplicationBaseUrl"
+          Write-Host "Test DLL: $env:TEST_DLL"
+
+          dotnet test $env:TEST_DLL --nologo --logger:trx `
+            --results-directory $resultsDirectory `
+            --settings $runSettingsPath
+
+
+      - name: Upload Acceptance Test Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: acceptance-test-results-tdd
+          path: build/test/AcceptanceTests/**/*.trx
+          retention-days: 2
+
+      - name: Report TDD status to commit
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: |
+          $sha = "${{ github.event.workflow_run.head_sha }}"
+          $runUrl = "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          $jobStatus = "${{ job.status }}"
+
+          if ($jobStatus -eq "success") {
+            $state = "success"
+            $description = "TDD deployment and acceptance tests passed"
+          } elseif ($jobStatus -eq "cancelled") {
+            $state = "pending"
+            $description = "TDD deployment was cancelled (superseded by a newer run)"
+          } else {
+            $state = "failure"
+            $description = "TDD deployment or acceptance tests failed"
+          }
+
+          gh api "repos/${{ github.repository }}/statuses/$sha" `
+            -f state="$state" `
+            -f target_url="$runUrl" `
+            -f description="$description" `
+            -f context="Deploy to TDD"
+
+  deploy-to-uat:
+    name: UAT
+    needs: [deploy-to-tdd]
+    if: >-
+      !cancelled() && (
+        github.event_name == 'workflow_dispatch' ||
+        (needs.deploy-to-tdd.result == 'success' &&
+         github.event.workflow_run.event == 'push' &&
+         (github.event.workflow_run.head_branch == 'master' ||
+          github.event.workflow_run.head_branch == 'main'))
+      )
+    concurrency:
+      group: deploy-to-uat-serialized
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    environment:
+      name: UAT
+
+    steps:
+      - name: Set Version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            version="${{ inputs.release_number }}"
+          else
+            version="${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ github.event.workflow_run.run_number }}"
+          fi
+          echo "BUILD_BUILDNUMBER=$version" >> $GITHUB_ENV
+          echo "VERSION=$version" >> $GITHUB_ENV
+          echo "Deploy version: $version"
+
+      - name: Deploy Octopus Release to UAT
+        uses: OctopusDeploy/deploy-release-action@v3
+        id: start-deploy-to-uat
+        env:
+          OCTOPUS_API_KEY: ${{ secrets.OCTO_API_KEY }}
+          OCTOPUS_URL: ${{ secrets.OCTOPUS_URL }}
+          OCTOPUS_SPACE: ${{ vars.OCTOPUS_SPACE }}
+        with:
+          project: ${{ vars.OCTOPUS_PROJECT }}
+          release_number: ${{ env.BUILD_BUILDNUMBER }}
+          environments: "UAT"
+
+      - name: Wait for the UAT deployment to complete
+        uses: OctopusDeploy/await-task-action@v3
+        env:
+          OCTOPUS_API_KEY: ${{ secrets.OCTO_API_KEY  }}
+          OCTOPUS_URL: ${{ secrets.OCTOPUS_URL }}
+          OCTOPUS_SPACE: ${{ vars.OCTOPUS_SPACE }}
+        with:
+          server_task_id: ${{ fromJson(steps.start-deploy-to-uat.outputs.server_tasks)[0].serverTaskId }}
+          timeout_after: 1800
+
+  deploy-to-prod:
+    name: Prod
+    needs: [deploy-to-uat]
+    if: success()
+    runs-on: ubuntu-latest
+    environment:
+      name: Prod
+
+    steps:
+      - name: Set Version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            version="${{ inputs.release_number }}"
+          else
+            version="${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ github.event.workflow_run.run_number }}"
+          fi
+          echo "BUILD_BUILDNUMBER=$version" >> $GITHUB_ENV
+          echo "VERSION=$version" >> $GITHUB_ENV
+          echo "Deploy version: $version"
+
+      - name: Deploy Octopus Release to Prod
+        uses: OctopusDeploy/deploy-release-action@v3
+        id: start-deploy-to-prod
+        env:
+          OCTOPUS_API_KEY: ${{ secrets.OCTO_API_KEY }}
+          OCTOPUS_URL: ${{ secrets.OCTOPUS_URL }}
+          OCTOPUS_SPACE: ${{ vars.OCTOPUS_SPACE }}
+        with:
+          project: ${{ vars.OCTOPUS_PROJECT }}
+          release_number: ${{ env.BUILD_BUILDNUMBER }}
+          environments: "Prod"
+
+      - name: Wait for the Prod deployment to complete
+        uses: OctopusDeploy/await-task-action@v3
+        env:
+          OCTOPUS_API_KEY: ${{ secrets.OCTO_API_KEY  }}
+          OCTOPUS_URL: ${{ secrets.OCTOPUS_URL }}
+          OCTOPUS_SPACE: ${{ vars.OCTOPUS_SPACE }}
+        with:
+          server_task_id: ${{ fromJson(steps.start-deploy-to-prod.outputs.server_tasks)[0].serverTaskId }}
+          timeout_after: 1800


### PR DESCRIPTION
## Summary

Updates the "Deploy to TDD" GitHub Actions workflow to report a `pending` status (yellow/amber) for runs that are cancelled due to a newer deployment taking precedence. This prevents misleading "failure" statuses for non-failed, superseded deployments.

## Related Issue

Closes #

## Changes Made

- Modified the `Report TDD status to commit` step in `.github/workflows/deploy.yml`.
- Added an `elseif` condition to explicitly check for `job.status == "cancelled"`.
- When a job is cancelled, the GitHub commit status is now set to `pending` with the description "TDD deployment was cancelled (superseded by a newer run)".

---

## Code Review Checklist

The following checklist will be used by the automated Cursor Cloud Agent reviewer. Ensure your PR addresses these items before marking it ready for review.

### Architecture Rules

- [ ] Layer boundaries respected (Presentation → Infrastructure → Application → Domain)
- [ ] No reverse dependencies (inner layers do not depend on outer layers)
- [ ] CQRS pattern followed for new features (Command/Query → Handler → DTO)
- [ ] Feature organization follows `Features/{Entity}/{Action}{Entity}/` structure
- [ ] Handlers return DTOs, never domain entities
- [x] No unauthorized changes to NuGet packages, SDK versions, or new projects

### Automated Testing

- [ ] Unit tests added/updated for new backend functionality
- [ ] Integration tests added/updated for component interactions
- [ ] Angular component tests added/updated for UI changes
- [x] All existing tests still pass (`scripts/build_and_test.ps1`)
- [ ] Tests follow Arrange-Act-Assert pattern
- [ ] Test coverage includes: dependencies called, business logic, state changes, return values, exceptions

### Documentation

- [ ] README updated if new features, scripts, or configuration added
- [ ] Code comments added for complex logic
- [ ] API contracts documented if endpoints changed

### Code Quality

- [x] No linter errors introduced
- [x] Consistent naming conventions followed
- [x] No hardcoded values that should be configuration
- [x] Error handling implemented appropriately
- [x] No security vulnerabilities introduced

### Issue Requirements

- [x] All acceptance criteria from the linked issue are addressed
- [ ] Implementation matches the technical design (if documented)
- [x] Edge cases and validation rules from the issue are handled

---

## Reviewer Notes

This change addresses the issue where a GitHub Actions job, when cancelled by a newer concurrent run, would incorrectly report a `failure` status. By explicitly checking for `cancelled` status and setting the commit status to `pending`, the PR will now show a yellow indicator, accurately reflecting that the run was inconclusive rather than a true failure.

The `pending` status was chosen as the most appropriate minimal change, as the GitHub Statuses API does not offer a "neutral" state. If "Deploy to TDD" is a required status check, a `pending` status will still block merging until the newer, superseding run completes.

---
<p><a href="https://cursor.com/agents/bc-280925ec-8222-4c31-9d24-ef667ae89bdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-280925ec-8222-4c31-9d24-ef667ae89bdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

